### PR TITLE
Fixing the CD pipeline

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -29,14 +29,20 @@ jobs:
           fi
 
           cd ${{ matrix.dir }}
-          npm ci
           PACKAGE_VERSION="$(cat package.json | jq -rM .version)"
+          GIT_TAG_NAME="${{ matrix.dir }}-v${PACKAGE_VERSION}"
+          if [[ -n "$(git ls-remote --tags origin "${GIT_TAG_NAME}")" ]]; then
+            # Tag already exists, meaning release has been done, so don't do anything here anymore
+            echo "Detected that tag ${GIT_TAG_NAME} already is created, not proceeding"
+            exit 0
+          fi
+
+          npm ci
           npm install --no-save @jsdevtools/npm-publish
           ./node_modules/.bin/npm-publish --access public --token '${{ secrets.NPM_TOKEN }}'
 
           # TODO we must generate release notes for the package
           # TODO set up organization-wide CICD-GitHub account
-          GIT_TAG_NAME="${{ matrix.dir }}-v${PACKAGE_VERSION}"
           git config --global user.email "cd-automation@dataheaving.project"
           git config --global user.name "CD Automation"
           git tag \


### PR DESCRIPTION
Auto-triggering CD pipeline now exits early if release for same version number has already been done (in this case, equivalent to git tag existing).